### PR TITLE
Fix/currency

### DIFF
--- a/StockQuoteAlert/Stocks/TwelveDataStockProvider.cs
+++ b/StockQuoteAlert/Stocks/TwelveDataStockProvider.cs
@@ -10,19 +10,20 @@ namespace StockQuoteAlert.Stocks
         private readonly string apiKey;
         private bool disposedValue;
 
-        private record class GetPriceResponse([property: JsonPropertyName("price")] string Price);
+        private record class GetQuoteResponse([property: JsonPropertyName("close")] string Close,
+                                              [property: JsonPropertyName("currency")] string Currency);
 
         public async Task<(decimal, string)> GetLatestStockPrice(string stockName)
         {
             var resp = await httpClient.GetAsync($"/price?apikey={apiKey}&symbol={stockName}");
             resp.EnsureSuccessStatusCode();
 
-            var body = await resp.Content.ReadFromJsonAsync<GetPriceResponse>();
+            var body = await resp.Content.ReadFromJsonAsync<GetQuoteResponse>();
 
             // After some API calls to TwelveData, a few responses came with "" in the
             // price field. These requests had no ApiKey, but returned that instead of 401.
             // Because of that, we'll assume empty strings mean "error".
-            if (string.IsNullOrEmpty(body?.Price))
+            if (string.IsNullOrEmpty(body?.Close))
             {
                 throw new Exception("An error occurred when calling TwelveData API. " +
                     "Check if the API Key is properly set in the config file.");
@@ -30,14 +31,14 @@ namespace StockQuoteAlert.Stocks
 
             // Make sure we parse with "InvariantCulture", otherwise we may get
             // wrong decimal points.
-            if (!decimal.TryParse(body?.Price,
+            if (!decimal.TryParse(body?.Close,
                                  NumberStyles.Number,
                                  CultureInfo.InvariantCulture,
                                  out var price))
             {
-                throw new Exception($"Invalid price format returned from TwelveData API: '{body?.Price}'");
+                throw new Exception($"Invalid price format returned from TwelveData API: '{body?.Close}'");
             }
-            return (price, "USD");
+            return (price, body.Currency.ToUpperInvariant());
         }
         
         public TwelveDataStockProvider(string apiKey)

--- a/StockQuoteAlert/Stocks/TwelveDataStockProvider.cs
+++ b/StockQuoteAlert/Stocks/TwelveDataStockProvider.cs
@@ -15,7 +15,7 @@ namespace StockQuoteAlert.Stocks
 
         public async Task<(decimal, string)> GetLatestStockPrice(string stockName)
         {
-            var resp = await httpClient.GetAsync($"/price?apikey={apiKey}&symbol={stockName}");
+            var resp = await httpClient.GetAsync($"/quote?apikey={apiKey}&symbol={stockName}");
             resp.EnsureSuccessStatusCode();
 
             var body = await resp.Content.ReadFromJsonAsync<GetQuoteResponse>();


### PR DESCRIPTION
Previous API calls to TwelveData assumed the API always returned USD. This fix corrects this behavior, switching the API from "/price" to "/quote" and using the "currency" response field.